### PR TITLE
Fix Cell.changeValue

### DIFF
--- a/lib/spreadsheets/Spreadsheets.js
+++ b/lib/spreadsheets/Spreadsheets.js
@@ -2,16 +2,18 @@
 
 var fs = require("fs"), querystring = require('querystring'), url = require("url");
 var path = require("path"), $ = require("jquery");
-var core = require("./core"), chain = require("./chain"), fork = require("./fork");
+var core = require("./core"), chain = require("./chain"), fork = require("./fork"), path = require('path');
 
 // extend jQuery
 (function($) {
 	$.fn.outerXml = function() {
 		var xml = this.wrap("<root/>").parent().html();
-		xml = xml.replace(/(<link[^\>]+>)/g, "$1</link>");
 		return xml;
 	};
 })($);
+
+// always assume xml to preserve capitalization of attributes
+$.isXMLDoc = function() { return true; };
 
 module.exports = exports = spreadsheets;
 
@@ -219,7 +221,7 @@ Spreadsheet.prototype.addWorksheet = function(settings, callback) {
 		path: "/feeds/worksheets/" + self._key + "/private/full",
 		headers: self._auth
 	};
-	var xml = $(fs.readFileSync("xml/worksheetentry.xml").toString());// TODO
+	var xml = $(fs.readFileSync(_modroot("xml/worksheetentry.xml")).toString());// TODO
 	// async
 	$("title", xml).text(settings.title || "untitled");
 	$("gs\\:rowCount", xml).text(settings.row || 100);
@@ -392,11 +394,11 @@ Worksheet.prototype.updateCells = function(vals, callback) {
 
 	var $feed;
 	chain.call(self, function(next) {
-		fs.readFile("xml/batchfeed.xml", "utf8", next);
+		fs.readFile(_modroot("xml/batchfeed.xml"), "utf8", next);
 	}, function(buf, next) {
 		$feed = $(buf.toString());
 		$("id", $feed).text(id);
-		fs.readFile("xml/batchcellentry.xml", "utf8", next);
+		fs.readFile(_modroot("xml/batchcellentry.xml"), "utf8", next);
 	}, function(buf, next) {
 		var xml = buf.toString(), opt = {
 			path: path + "/batch",
@@ -445,7 +447,7 @@ function Row(key, worksheet) {
 function Cell(key, title, val, worksheet) {
 	var self = this;
 	if(!(self instanceof Cell))
-		return new Cell(key, worksheet);
+		return new Cell(key, title, val, worksheet);
 	var rc = (new RegExp("^R(\\d+)C(\\d+)$")).exec(key);
 	self._key = key, self._row = +rc[1], self._col = +rc[2];
 	self._title = title, self._value = val, self._parent = worksheet;
@@ -464,7 +466,7 @@ Cell.prototype.changeValue = function(val, callback) {
 			+ self._key;
 
 	chain.call(self, function(next) {
-		fs.readFile("xml/cellentry.xml", "utf8", next);
+		fs.readFile(_modroot("xml/cellentry.xml"), "utf8", next);
 	}, function(buf, next) {
 		var $xml = $(buf.toString());
 		var id = "https://spreadsheets.google.com" + path;
@@ -514,3 +516,7 @@ Cell.prototype._get = function(callback) {
 		callback.call(self, null, cell);
 	});
 };
+
+function _modroot(p) {
+	return path.join(__dirname, '..', '..', p);
+}


### PR DESCRIPTION
Tested on node-jquery 1.7.2: jQuery lowercases all attribute names if the root element node type is HTML. The [content cell change protocol](https://developers.google.com/google-apps/spreadsheets/#changing_contents_of_a_cell) for Google Spreadseets requires an `inputValue` attribute on the `<gs:cell>` element where `inputValue` is not all lowercase. Since this library uses jQuery to always manipulate XML, force `jQuery.isXMLDoc()` to always return true.

Also:
- Remove manipulation of <link> elements in `outerXml()`. It yielded wrong XML output for e.g. `<link x="f" />`.
- Fix call to Cell constructor function.
- XML templates are now relative to the module root and not current directory
